### PR TITLE
Improve projectiles by separating WeaponFire from ProjectileFire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,9 +1234,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_materialize"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911eaa27cd446a9e95f18c7c234b6a8c036ae47b4632e09bbdf5326c3f1f0bc5"
+checksum = "20040879c95d5f3210eafd7fc00d64e9e75b5cc7eddbedfc752bd9c73b8b12e2"
 dependencies = [
  "bevy",
  "serde",
@@ -1620,9 +1620,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_trenchbroom"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34467f8088d997444e0cfdd7f17a3c929894eb3557b5ca62ddbbd86c7a97260"
+checksum = "00ed5bb471e9b65df4c4b6313de1578577f6bab75466e73af66e8d145d7bf49c"
 dependencies = [
  "anyhow",
  "avian3d",
@@ -1649,9 +1649,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_trenchbroom_macros"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025a890d6eaec92b4ee7105660a73319054b6fe97d5a925e3691cfebd800bd9f"
+checksum = "d705a6b59b24c75bb34f71b84249fb5625a53298e0737870613fa1a799e67993"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3072,9 +3072,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "font-types"
@@ -4302,7 +4302,7 @@ dependencies = [
 [[package]]
 name = "lightyear"
 version = "0.19.0"
-source = "git+https://github.com/cBournhonesque/lightyear.git?branch=main#9f3f3c02d2377662e645d6719217b9763d539af0"
+source = "git+https://github.com/cBournhonesque/lightyear.git?branch=main#2037d468f513569deee79ca24e0eb06c2a4c35ea"
 dependencies = [
  "async-channel",
  "async-compat",
@@ -4346,7 +4346,7 @@ dependencies = [
 [[package]]
 name = "lightyear_avian"
 version = "0.19.0"
-source = "git+https://github.com/cBournhonesque/lightyear.git?branch=main#9f3f3c02d2377662e645d6719217b9763d539af0"
+source = "git+https://github.com/cBournhonesque/lightyear.git?branch=main#2037d468f513569deee79ca24e0eb06c2a4c35ea"
 dependencies = [
  "avian3d",
  "bevy",
@@ -4387,7 +4387,7 @@ dependencies = [
 [[package]]
 name = "lightyear_macros"
 version = "0.19.0"
-source = "git+https://github.com/cBournhonesque/lightyear.git?branch=main#9f3f3c02d2377662e645d6719217b9763d539af0"
+source = "git+https://github.com/cBournhonesque/lightyear.git?branch=main#2037d468f513569deee79ca24e0eb06c2a4c35ea"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/client/src/weapon.rs
+++ b/client/src/weapon.rs
@@ -1,38 +1,59 @@
 use std::time::Duration;
 use avian3d::collision::CollisionLayers;
-use avian3d::prelude::{LinearVelocity, Position, RigidBody, Rotation, SpatialQuery, SpatialQueryFilter};
+use avian3d::prelude::{LinearVelocity, PhysicsSet, Position, RigidBody, Rotation, SpatialQuery, SpatialQueryFilter};
 use bevy::{prelude::*};
 use leafwing_input_manager::prelude::ActionState;
 use lightyear::{shared::replication::components::Controlled};
-use lightyear::prelude::{is_host_server, TickManager};
+use lightyear::client::sync::SyncSet;
+use lightyear::prelude::{is_host_server, FromServer, MainSet, Tick, TickManager};
 use lightyear::prelude::client::*;
+use lightyear::utils::ready_buffer::ReadyBuffer;
 use shared::{prelude::{CurrentWeaponIndex, GameLayer, PlayerInput, UniqueIdentity}, weapons::{handle_shooting, Projectile, WeaponFiredEvent, WeaponInventory, WeaponsData}};
-use shared::prelude::{DespawnAfter, WeaponsSet};
+use shared::prelude::{DespawnAfter, ProjectileInfo, Ship, WeaponsSet};
 
 pub(crate) struct WeaponPlugin;
 
 impl Plugin for WeaponPlugin {
     fn build(&self, app: &mut App) {
+        app.init_resource::<WeaponFiredEventInterpolationBuffer>();
         // do not shoot a bullet twice if we are the host-server!
-        app.add_systems(FixedUpdate, shoot_system
+        app.add_systems(FixedUpdate, predicted_shoot_system
             .in_set(WeaponsSet::Shoot)
             .run_if(not(is_host_server)));
 
-        // TODO: currently we run this in FixedUpdate to fire at the exact tick that the server fired the bullet.
-        //  this might not really make sense as the interpolation_tick is only updated outside of FixedUpdate.
-        //  Maybe run this in PostUpdate?
-        app.add_systems(FixedUpdate, shoot_interpolated_bullets
+        app.add_systems(PreUpdate, buffer_fire_weapon_event
+            .after(MainSet::ReceiveEvents));
+        app.add_systems(PostUpdate, shoot_interpolated_bullets
             .in_set(WeaponsSet::Shoot)
-            .run_if(not(is_host_server).and(not(is_in_rollback))));
+            // the interpolation time is updated in the lightyear SyncSet
+            .after(SyncSet)
+            // make sure that any Position is propagated to Transform
+            .before(PhysicsSet::Sync)
+            .run_if(not(is_host_server))
+        );
 
-        app.add_systems(FixedPostUpdate, (
-            projectile_predict_hit_detection_system,
-        ));
+        // app.add_systems(FixedPostUpdate, (
+        //     projectile_predict_hit_detection_system,
+        // ));
     }
 }
 
 
-fn shoot_system(
+/// When we receive FiredWeaponEvent from the server, we don't want to immediately fire the weapon.
+/// Instead, we want to wait for the event tick to match the interpolated timeline.
+/// We will store the events in a heap and wait until the interpolation tick matches the event tick.
+#[derive(Resource, Default)]
+struct WeaponFiredEventInterpolationBuffer {
+    buffer: ReadyBuffer<Tick, WeaponFiredEvent>
+}
+
+
+/// System to fire weapon for the local client.
+/// The weapon is fired in the prediction timeline.
+/// Normally we would PreSpawn the projectile entities and match them with server-replicated entities; but to save
+/// bandwidth we will simply spawn the projectile on the client and the server, with no replication.
+// TODO(cb): this might not work if the player is 'stunned' or 'dead' on the server but can shoot on the client.
+fn predicted_shoot_system(
     fixed_time: Res<Time<Fixed>>,
     mut commands: Commands,
     weapons_data: Res<WeaponsData>,
@@ -56,12 +77,14 @@ fn shoot_system(
 
     let tick = tick_manager.tick();
     for (shooting_entity, position, rotation, mut inventory, action) in predicted_player.iter_mut() {
+        // TODO: what is this? why don't we check the CurrentWeapon / Identity directly on the predicted entity?
         if let Some((identity, current_weapon_idx)) = non_predicted_controlled_player.iter().next() {
             handle_shooting(
                 shooting_entity, 
                 identity,
                 tick,
                 false,
+                None,
                 position,
                 rotation,
                 current_weapon_idx.0,
@@ -75,48 +98,46 @@ fn shoot_system(
     }
 }
 
+/// Store the events in a buffer until the interpolation tick matches the event tick
+fn buffer_fire_weapon_event(
+    mut buffer: ResMut<WeaponFiredEventInterpolationBuffer>,
+    mut events: ResMut<Events<FromServer<WeaponFiredEvent>>>,
+) {
+    events.drain().for_each(|event| {
+        buffer.buffer.push(event.message.fire_tick, event.message);
+    })
+}
+
 // TODO: should this be an observer? maybe not because there could be many bullets fired per round
 /// When we receive an interpolated entity with FiredWeaponEvent from the server, we make sure to fire
 /// the bullet at the correct time and position
 fn shoot_interpolated_bullets(
     mut commands: Commands,
     tick_manager: Res<TickManager>,
-    weapons_data: Res<WeaponsData>,
     connection: Res<ConnectionManager>,
-    interpolated_bullet: Query<
-        (Entity, &WeaponFiredEvent),
-        // optimization trick to avoid using Added
-        (With<Interpolated>, Without<Projectile>)
-    >
+    mut buffer: ResMut<WeaponFiredEventInterpolationBuffer>,
+    ship_query: Query<&Confirmed, With<Ship>>,
 ) {
     let interpolate_tick = connection.interpolation_tick(tick_manager.as_ref());
-    interpolated_bullet.iter().for_each(|(entity, fired_event)| {
-        // TODO: 2 options
-        //  - wait for the correct tick to arrive
-        //  - fire the bullet immediately with some position adjustments based on the tick diff
-        if interpolate_tick < fired_event.fire_tick {
-            return;
-        }
-        // NOTE: this assert fails, probably because we don't update the ticks linearly in FixedUpdate,
-        //  instead they are updated based on interpolated_time and sync...
-        //  for now let's just fire the projectile if the interpolation tick is in the future compared
-        //  to the firing tick. Maybe we can do visual adjustments.
-        // assert_eq!(fired_event.fire_tick, interpolate_tick);
-        if let Some(weapon_data) = weapons_data.weapons.get(&fired_event.weapon_index) {
-            debug!(?fired_event, ?interpolate_tick, "Adding components for interpolated bullet!");
-            commands.entity(entity)
-                .insert((
-                    // TODO: have a better way to do this 'spawn on the interpolation timeline' logic
-                    // TODO: avoid this repeated code
-                    Projectile,
-                    Position(fired_event.fire_origin),
-                    LinearVelocity(fired_event.fire_direction.as_vec3() * weapon_data.projectile.speed),
-                    DespawnAfter(Timer::new(Duration::from_millis(weapon_data.projectile.lifetime_millis), TimerMode::Once)),
-                    RigidBody::Dynamic,
-                    CollisionLayers::new([GameLayer::Projectile], [GameLayer::Ship, GameLayer::Wall]),
-                ));
-        }
-    })
+    // we wait and only pop the fire events that are more recent than the interpolate_tick
+    while let Some((_, mut fired_event)) = buffer.buffer.pop_item(&interpolate_tick)  {
+        // the entity here is the Confirmed entity, and we need to get the interpolated entity.
+        let Ok(confirmed) = ship_query.get(fired_event.shooter_entity) else {
+            error!("Could not find Confirmed ship from fired event: {:?}", fired_event);
+            continue
+        };
+
+        let Some(interpolated_entity) = confirmed.interpolated else {
+            error!("Could not find interpolated entity from fired event: {:?}", fired_event);
+            continue
+        };
+
+        debug!(?interpolate_tick, "Trigger fired event: {:?} on interpolated entity", fired_event);
+        // mark the interpolated entity as the shooter
+        fired_event.shooter_entity = interpolated_entity;
+        // trigger the event so we spawn the projectiles + add audio/vfx
+        commands.trigger(fired_event);
+    }
 }
 
 // TODO: instead of using spatial-query, we can directly use Collisions ?
@@ -126,18 +147,18 @@ fn projectile_predict_hit_detection_system(
     fixed_time: Res<Time<Fixed>>,
     mut commands: Commands,
     spatial_query: SpatialQuery,
-    projectiles: Query<(Entity, &Position, &LinearVelocity, &WeaponFiredEvent), With<Projectile>>,
+    projectiles: Query<(Entity, &Position, &LinearVelocity, &ProjectileInfo), With<Projectile>>,
 ) {
-    for (bullet_entity, current_pos, current_velocity, fired_event) in projectiles.iter() {
+    for (bullet_entity, current_pos, current_velocity, projectile_info) in projectiles.iter() {
         if let Some(_) = spatial_query.cast_ray(
             current_pos.0,
-            Dir3::from_xyz(current_velocity.0.x, current_velocity.0.y, current_velocity.0.z).unwrap_or(fired_event.fire_direction),
+            Dir3::new_unchecked(current_velocity.0.normalize()),
             current_velocity.length() * fixed_time.delta_secs(),
             true,
             &mut SpatialQueryFilter {
                 mask: [GameLayer::Ship, GameLayer::Wall].into(),
                 ..default()
-            }.with_excluded_entities([fired_event.shooter_entity])
+            }.with_excluded_entities([projectile_info.shooter_entity])
         ) {
             // @todo-brian: do bouncy projectiles!
             commands.entity(bullet_entity).despawn_recursive();

--- a/shared/src/network/protocol.rs
+++ b/shared/src/network/protocol.rs
@@ -23,7 +23,7 @@ pub struct ProtocolPlugin;
 
 
 #[derive(Channel)]
-pub struct Channel1;
+pub struct WeaponFiredChannel;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy, Hash, Reflect, Actionlike)]
 pub enum PlayerInput {
@@ -52,8 +52,8 @@ pub enum PlayerInput {
 impl Plugin for ProtocolPlugin {
     fn build(&self, app: &mut App) {
         // Channels
-        app.add_channel::<Channel1>(ChannelSettings {
-            mode: ChannelMode::OrderedReliable(ReliableSettings::default()),
+        app.add_channel::<WeaponFiredChannel>(ChannelSettings {
+            mode: ChannelMode::UnorderedReliable(ReliableSettings::default()),
             ..default()
         });
 
@@ -66,6 +66,11 @@ impl Plugin for ProtocolPlugin {
             }
         });
 
+        // Messages
+        app.register_message::<WeaponFiredEvent>(ChannelDirection::ServerToClient)
+            .add_map_entities();
+
+        // Components
         app.register_component::<Name>(ChannelDirection::ServerToClient)
             .add_prediction(ComponentSyncMode::Once)
             .add_interpolation(ComponentSyncMode::Once);
@@ -73,10 +78,6 @@ impl Plugin for ProtocolPlugin {
         app.register_component::<Projectile>(ChannelDirection::ServerToClient)
             .add_interpolation(ComponentSyncMode::Once);
         
-        app.register_component::<WeaponFiredEvent>(ChannelDirection::ServerToClient)
-            .add_interpolation(ComponentSyncMode::Once)
-            .add_map_entities();
-
         app.register_component::<PlayerShip>(ChannelDirection::ServerToClient)
             .add_prediction(ComponentSyncMode::Simple)
             .add_interpolation(ComponentSyncMode::Simple);
@@ -117,11 +118,6 @@ impl Plugin for ProtocolPlugin {
 
         // do not replicate Transform but make sure to register an interpolation function
         // for it so that we can do visual interpolation
-        // (another option would be to replicate transform and not use Position/Rotation at all)
-        // app.register_component::<Transform>(ChannelDirection::ServerToClient)
-        //     .add_prediction(ComponentSyncMode::Full)
-        //     .add_interpolation(ComponentSyncMode::Full)
-        //     .add_interpolation_fn(TransformLinearInterpolation::lerp);
         app.add_interpolation::<Transform>(ComponentSyncMode::None);
         app.add_interpolation_fn::<Transform>(TransformLinearInterpolation::lerp);
 


### PR DESCRIPTION
Fixes https://github.com/cBournhonesque/sixdof/issues/42

We don't want to send a message for each individual bullet getting fired because that could be too much (imagine a shotgun that fires 100 bullets).
Also the design of sending a `WeaponFiredEvent` as a component was a bit awkward. I refactored the code to:
- make `WeaponFiredEvent` an event again. That event contains all the information necessary to fire the necessary projectiles.
- when `WeaponFiredEvent` is triggered, we play a sound (via observer) and fire the projectiles (via observer)
- on the server, we will replicate the `WeaponFiredEvent` event to other clients. These clients will buffer the message in a local interpolation buffer, and then trigger the event only when the interpolation tick is reached